### PR TITLE
Tweak panels to match WWW better

### DIFF
--- a/src/components/_panels.scss
+++ b/src/components/_panels.scss
@@ -18,18 +18,19 @@ limitations under the License.
   background: $background;
   border: $thin-border;
   border-radius: $border-radius;
-  box-shadow: none;
+  box-shadow: 0 2px 4px rgba($dark-blue, .06);
   color: $text;
   margin: 1rem .5rem;
   padding: .5rem;
   text-align: center;
+  transition: box-shadow $transition, opacity $transition;
   width: 100%;
 
-  &.selectable {
+  &.is-selectable {
     cursor: pointer;
 
     &:hover {
-      background: $panel;
+      box-shadow: 0 10px 20px rgba($dark-blue, .1);
     }
   }
 
@@ -58,6 +59,11 @@ limitations under the License.
         font-size: $font-size * .8;
       }
 
+      sup {
+        line-height: inherit;
+        top: 0;
+      }
+
       sub {
         color: $text-secondary;
         vertical-align: baseline;
@@ -69,7 +75,21 @@ limitations under the License.
         margin: 0;
         padding: .2rem .4rem;
       }
+
+      small {
+        em {
+          font-size: 18px;
+        }
+      }
     }
+  }
+
+  &.is-focused {
+    box-shadow: 0 10px 20px rgba($dark-blue, .1);
+  }
+
+  &.is-unfocused {
+    opacity: .65;
   }
 }
 

--- a/test/templates/app.vue
+++ b/test/templates/app.vue
@@ -330,8 +330,9 @@ limitations under the License.
                     </h2>
                     <hr/>
 
+                    <h3>Horizontal panel list, is-selectable &amp; is-droplet</h3>
                     <div class="panel-list">
-                        <div class="panel selectable is-droplet" v-for="_ in 3">
+                        <div class="panel is-selectable is-droplet" v-for="_ in 3">
                             <p><em><sup>$</sup>10<sub> / mo</sub></em></p>
                             <p>Hover over me!</p>
                             <hr/>
@@ -340,8 +341,9 @@ limitations under the License.
                         </div>
                     </div>
 
+                    <h3>Vertical panel list, is-droplet &amp; is-focused / is-unfocused</h3>
                     <div class="panel-list panel-list-vertical">
-                        <div class="panel is-droplet" v-for="_ in 3">
+                        <div :class="`panel is-droplet is-${i === 1 ? '' : 'un'}focused`" v-for="i in 3">
                             <p><em><sup>$</sup>10<sub> / mo</sub></em></p>
                             <hr/>
                             <p>Fast disk <sub> / SSD magic</sub></p>


### PR DESCRIPTION
## Type of Change

Component styling - panels.

## What issue does this relate to?

For use in https://github.com/do-community/bandwidth-tool/pull/10

### What should this PR do?

Tweaks panels to better match [WWW](https://www.digitalocean.com/products/droplets/) and also use more consistent class names like bulma.

### What are the acceptance criteria?

Looks fine, makes sense.