### PR TITLE
Fix min-height for wrapper + landing

### DIFF
--- a/src/components/_base.scss
+++ b/src/components/_base.scss
@@ -77,7 +77,6 @@ figure {
   flex-direction: column;
   line-height: $line-height;
   margin: 0;
-  min-height: 100vh;
   padding: 0;
   text-rendering: optimizeLegibility;
 

--- a/src/components/_landing.scss
+++ b/src/components/_landing.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ limitations under the License.
 .landing {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - 171px); // Account for Community nav height
+  min-height: calc(100vh - (var(--top-hat-height, 0px) + var(--primary-nav-height, 0px) + var(--sub-nav-height, 0px))); // Account for Community nav height
   position: relative;
 
   .container {


### PR DESCRIPTION
## Type of Change

Wrapper

## What issue does this relate to?

N/A

### What should this PR do?

Removes the generic min-height from the do-bulma main wrapper, and updates the min-height on the landing wrapper to make use of the CSS variables now available on the DigitalOcean site.

### What are the acceptance criteria?

Min-height removed from main wrapper.

Correct CSS variables used for landing wrapper.
